### PR TITLE
chore(App-1416): make repo compatible with Cordova 9

### DIFF
--- a/hooks/after_prepare.js
+++ b/hooks/after_prepare.js
@@ -1,46 +1,66 @@
-var path = require('path');
-var fs = require('fs');
-var xcodeHelpers = require('./lib/xcode-helpers');
-var preferencesParser = require('./lib/preferences-parser');
+var path = require("path");
+var fs = require("fs");
+var xcodeHelpers = require("./lib/xcode-helpers");
+var preferencesParser = require("./lib/preferences-parser");
 
-module.exports = function(ctx) {
-
-  if (ctx.opts.platforms.indexOf('ios') === -1) {
+module.exports = function (ctx) {
+  if (ctx.opts.platforms.indexOf("ios") === -1) {
     return;
   }
 
-  glob = ctx.requireCordovaModule('glob');
-  xcode = ctx.requireCordovaModule('xcode');
+  glob = require("glob");
+  xcode = require("xcode");
   var projectRoot = ctx.opts.projectRoot;
-  var configXml = path.join(projectRoot, 'config.xml');
+  var configXml = path.join(projectRoot, "config.xml");
   var preferences = preferencesParser.parseConfigXml(configXml);
-  var entitlementsSrcFile = preferences['cordova-ios-entitlements-file'];
+  var entitlementsSrcFile = preferences["cordova-ios-entitlements-file"];
   if (!entitlementsSrcFile) {
-    console.error('cordova-ios-entitlements: preference "cordova-ios-entitlements-file" must be set');
+    console.error(
+      'cordova-ios-entitlements: preference "cordova-ios-entitlements-file" must be set'
+    );
     return;
   }
-  var entitlementsContent = fs.readFileSync(path.join(projectRoot, entitlementsSrcFile),'utf8');
+  var entitlementsContent = fs.readFileSync(
+    path.join(projectRoot, entitlementsSrcFile),
+    "utf8"
+  );
 
-  var cordovaIosProjectPath = path.join(projectRoot, 'platforms', 'ios');
-  var pbxprojFile = glob.sync(path.join(cordovaIosProjectPath, '*.xcodeproj', 'project.pbxproj'))[0];
+  var cordovaIosProjectPath = path.join(projectRoot, "platforms", "ios");
+  var pbxprojFile = glob.sync(
+    path.join(cordovaIosProjectPath, "*.xcodeproj", "project.pbxproj")
+  )[0];
   var xcodeProjectFolderPath = path.dirname(pbxprojFile);
   var xcodeProjectFolderName = path.basename(xcodeProjectFolderPath);
 
   if (!pbxprojFile) {
-    throw new Error('cordova-ios-entitlements: could not find project.pbxproj file');
+    throw new Error(
+      "cordova-ios-entitlements: could not find project.pbxproj file"
+    );
   }
 
   var xcodeProject = xcode.project(pbxprojFile);
   xcodeProject.parseSync();
 
-  var entitlementsDestinationFileName = 'Entitlements.entitlements';
-  var entitlementsDestinationFilePath = path.join(xcodeProjectFolderPath, entitlementsDestinationFileName);
-  var entitlementsXcodeFilePath = path.join(xcodeProjectFolderName, entitlementsDestinationFileName);
-  
+  var entitlementsDestinationFileName = "Entitlements.entitlements";
+  var entitlementsDestinationFilePath = path.join(
+    xcodeProjectFolderPath,
+    entitlementsDestinationFileName
+  );
+  var entitlementsXcodeFilePath = path.join(
+    xcodeProjectFolderName,
+    entitlementsDestinationFileName
+  );
+
   fs.writeFileSync(entitlementsDestinationFilePath, entitlementsContent);
 
-  xcodeHelpers.addEntitlementsFileToProject(xcodeProject, entitlementsXcodeFilePath);
-  xcodeHelpers.useCodeSignEntitlementsForConfiguration(xcodeProject, entitlementsXcodeFilePath);
+  xcodeHelpers.addEntitlementsFileToProject(
+    xcodeProject,
+    entitlementsXcodeFilePath
+  );
+  xcodeHelpers.useCodeSignEntitlementsForConfiguration(
+    xcodeProject,
+    entitlementsXcodeFilePath
+  );
 
   fs.writeFileSync(pbxprojFile, xcodeProject.writeSync());
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-ios-entitlements",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Entitlements plugin for Cordova",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
## Description

Cordova 9.0.0 has deprecated `requiredCordovaModule` to load non cordova module, instead the common `require` must be used.

## Changes
- replaced `requireCordovaModule` by `require`
- bumped version to 2.0.0